### PR TITLE
Moved some calculations from Nx to Gleam

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,8 +10,8 @@ repository = { type = "github", user = "lucaspellegrinelli", repo = "gleastsq" }
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 gleam_otp = ">= 0.10.0 and < 1.0.0"
 nx = ">= 0.7.2 and < 1.0.0"
+gleam_community_maths = ">= 1.1.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 prng = ">= 3.0.3 and < 4.0.0"
-gleam_community_maths = ">= 1.1.1 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -15,7 +15,7 @@ packages = [
 ]
 
 [requirements]
-gleam_community_maths = { version = ">= 1.1.1 and < 2.0.0" }
+gleam_community_maths = { version = ">= 1.1.1 and < 2.0.0"}
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/gleastsq/internal/jacobian.gleam
+++ b/src/gleastsq/internal/jacobian.gleam
@@ -8,9 +8,9 @@ pub opaque type JacobianError {
 }
 
 pub fn jacobian(
-  x: NxTensor,
+  x: List(Float),
   y_fit: NxTensor,
-  func: fn(NxTensor, NxTensor) -> Float,
+  func: fn(Float, List(Float)) -> Float,
   params: NxTensor,
   epsilon: Float,
 ) {
@@ -32,9 +32,9 @@ pub fn jacobian(
 }
 
 fn compute_jacobian_col(
-  x: NxTensor,
+  x: List(Float),
   y_fit: NxTensor,
-  func: fn(NxTensor, NxTensor) -> Float,
+  func: fn(Float, List(Float)) -> Float,
   params: NxTensor,
   epsilon: Float,
   n: Int,
@@ -49,6 +49,6 @@ fn compute_jacobian_col(
   let zeros_n = nx.broadcast(0.0, #(n))
   let mask = nx.indexed_put(zeros_n, nx.tensor([i]), epsilon)
   let up_params = nx.add(params, mask)
-  let up_f = nx.map(x, func(_, up_params))
+  let up_f = list.map(x, func(_, nx.to_list_1d(up_params))) |> nx.tensor
   nx.new_axis(nx.divide(nx.subtract(up_f, y_fit), epsilon), 1)
 }

--- a/src/gleastsq/internal/jacobian.gleam
+++ b/src/gleastsq/internal/jacobian.gleam
@@ -39,19 +39,13 @@ fn compute_jacobian_col(
   epsilon: Float,
   i: Int,
 ) -> NxTensor {
-  // Originally this was implemented by calculating a "up_f" and a "down_f" and then
-  // the jacobian column was calculated as (up_f - down_f) / (2 * epsilon).
-  // But since the main bottleneck of this function is calling the Gleam function in
-  // every Elixir Nx's maps (because of gleastsq/internal/nx.{convert_func_params}),
-  // it was decided to calculate the jacobian column as (up_f - y_fit) / epsilon where
-  // "y_fit" is the result of the function with the original parameters.
-
-  let up_params = params |> list.index_map(fn(v, idx) {
-    case idx == i {
-      True -> v +. epsilon
-      False -> v
-    }
-  })
+  let up_params =
+    list.index_map(params, fn(v, idx) {
+      case idx == i {
+        True -> v +. epsilon
+        False -> v
+      }
+    })
 
   let up_f = list.map(x, func(_, up_params)) |> nx.tensor
   nx.new_axis(nx.divide(nx.subtract(up_f, y_fit), epsilon), 1)

--- a/src/gleastsq/internal/methods/gauss_newton.gleam
+++ b/src/gleastsq/internal/methods/gauss_newton.gleam
@@ -83,7 +83,7 @@ fn do_gauss_newton(
     iterations -> {
       let r = nx.subtract(y, y_fit)
       use j <- result.try(result.replace_error(
-        jacobian(nx.to_list_1d(x), y_fit, func, params, epsilon),
+        jacobian(list_x, y_fit, func, params, epsilon),
         JacobianTaskError,
       ))
 

--- a/src/gleastsq/internal/methods/gauss_newton.gleam
+++ b/src/gleastsq/internal/methods/gauss_newton.gleam
@@ -45,7 +45,7 @@ pub fn gauss_newton(
     Error(WrongParameters("x and y must have the same length")),
   )
 
-  let x = nx.tensor(x)
+  let x = nx.tensor(x) |> nx.to_list_1d
   let y = nx.tensor(y)
   let iter = option.unwrap(opts.iterations, 100)
   let eps = option.unwrap(opts.epsilon, 0.0001)
@@ -66,7 +66,7 @@ pub fn gauss_newton(
 }
 
 fn do_gauss_newton(
-  x: NxTensor,
+  x: List(Float),
   y: NxTensor,
   func: fn(Float, List(Float)) -> Float,
   params: List(Float),
@@ -76,14 +76,13 @@ fn do_gauss_newton(
   lambda_reg: Float,
 ) {
   let m = list.length(params)
-  let list_x = nx.to_list_1d(x)
-  let y_fit = list_x |> list.map(func(_, params)) |> nx.tensor
+  let y_fit = list.map(x, func(_, params)) |> nx.tensor
   case max_iterations {
     0 -> Error(NonConverged)
     iterations -> {
       let r = nx.subtract(y, y_fit)
       use j <- result.try(result.replace_error(
-        jacobian(list_x, y_fit, func, params, epsilon),
+        jacobian(x, y_fit, func, params, epsilon),
         JacobianTaskError,
       ))
 

--- a/src/gleastsq/internal/methods/levenberg_marquardt.gleam
+++ b/src/gleastsq/internal/methods/levenberg_marquardt.gleam
@@ -100,7 +100,7 @@ fn do_levenberg_marquardt(
     iterations -> {
       let r = nx.subtract(y, y_fit)
       use j <- result.try(result.replace_error(
-        jacobian(nx.to_list_1d(x), y_fit, func, params, epsilon),
+        jacobian(list_x, y_fit, func, params, epsilon),
         JacobianTaskError,
       ))
 

--- a/src/gleastsq/internal/methods/levenberg_marquardt.gleam
+++ b/src/gleastsq/internal/methods/levenberg_marquardt.gleam
@@ -51,7 +51,6 @@ pub fn levenberg_marquardt(
   let p = nx.tensor(initial_params)
   let x = nx.tensor(x)
   let y = nx.tensor(y)
-  let func = nx.convert_func_params(func)
   let iter = option.unwrap(opts.iterations, 100)
   let eps = option.unwrap(opts.epsilon, 0.0001)
   let tol = option.unwrap(opts.tolerance, 0.0001)
@@ -84,7 +83,7 @@ fn ternary(cond: Bool, a: a, b: a) -> a {
 fn do_levenberg_marquardt(
   x: NxTensor,
   y: NxTensor,
-  func: fn(NxTensor, NxTensor) -> Float,
+  func: fn(Float, List(Float)) -> Float,
   params: NxTensor,
   max_iterations: Int,
   epsilon: Float,
@@ -94,13 +93,14 @@ fn do_levenberg_marquardt(
   damping_decrease: Float,
 ) -> Result(NxTensor, FitErrors) {
   let m = nx.shape(params).0
-  let y_fit = nx.map(x, func(_, params))
+  let y_fit =
+    x |> nx.to_list_1d |> list.map(func(_, nx.to_list_1d(params))) |> nx.tensor
   case max_iterations {
     0 -> Error(NonConverged)
     iterations -> {
       let r = nx.subtract(y, y_fit)
       use j <- result.try(result.replace_error(
-        jacobian(x, y_fit, func, params, epsilon),
+        jacobian(nx.to_list_1d(x), y_fit, func, params, epsilon),
         JacobianTaskError,
       ))
 
@@ -114,7 +114,9 @@ fn do_levenberg_marquardt(
       case nx.to_number(nx.norm(delta)) {
         x if x <. tolerance -> Ok(new_params)
         _ -> {
-          let new_r = x |> nx.map(func(_, new_params)) |> nx.subtract(y, _)
+          let new_y_fit =
+            x |> nx.to_list_1d |> list.map(func(_, nx.to_list_1d(new_params))) |> nx.tensor
+          let new_r = nx.subtract(y, new_y_fit)
           let prev_error = nx.sum(nx.pow(r, 2.0)) |> nx.to_number
           let new_error = nx.sum(nx.pow(new_r, 2.0)) |> nx.to_number
           let impr = new_error <. prev_error

--- a/src/gleastsq/internal/nx.gleam
+++ b/src/gleastsq/internal/nx.gleam
@@ -68,10 +68,10 @@ pub fn put_slice(a: NxTensor, indices: List(Int), value: NxTensor) -> NxTensor
 @external(erlang, "Elixir.Nx", "concatenate")
 pub fn concatenate(a: List(NxTensor), opts opts: List(NxOpts)) -> NxTensor
 
-pub fn convert_func_params(
-  func: fn(Float, List(Float)) -> Float,
-) -> fn(NxTensor, NxTensor) -> Float {
-  fn(x: NxTensor, params: NxTensor) -> Float {
-    func(to_number(x), to_list_1d(params))
-  }
-}
+// pub fn convert_func_params(
+//   func: fn(Float, List(Float)) -> Float,
+// ) -> fn(NxTensor, NxTensor) -> Float {
+//   fn(x: NxTensor, params: NxTensor) -> Float {
+//     func(to_number(x), to_list_1d(params))
+//   }
+// }

--- a/src/gleastsq/internal/nx.gleam
+++ b/src/gleastsq/internal/nx.gleam
@@ -14,9 +14,6 @@ pub fn eye(n: Int) -> NxTensor
 @external(erlang, "Elixir.Nx", "dot")
 pub fn dot(a: NxTensor, b: NxTensor) -> NxTensor
 
-@external(erlang, "Elixir.Nx", "map")
-pub fn map(a: NxTensor, f: fn(NxTensor) -> Float) -> NxTensor
-
 @external(erlang, "Elixir.Nx", "multiply")
 pub fn multiply(a: NxTensor, b: Float) -> NxTensor
 
@@ -44,17 +41,8 @@ pub fn to_list_1d(a: NxTensor) -> List(Float)
 @external(erlang, "Elixir.Nx", "to_number")
 pub fn to_number(a: NxTensor) -> Float
 
-@external(erlang, "Elixir.Nx.LinAlg", "norm")
-pub fn norm(a: NxTensor) -> NxTensor
-
 @external(erlang, "Elixir.Nx.LinAlg", "solve")
 pub fn solve(a: NxTensor, b: NxTensor) -> NxTensor
-
-@external(erlang, "Elixir.Nx", "broadcast")
-pub fn broadcast(a: Float, shape: a) -> NxTensor
-
-@external(erlang, "Elixir.Nx", "indexed_put")
-pub fn indexed_put(a: NxTensor, indices: NxTensor, value: Float) -> NxTensor
 
 @external(erlang, "Elixir.Nx", "new_axis")
 pub fn new_axis(a: NxTensor, axis: Int) -> NxTensor
@@ -62,16 +50,5 @@ pub fn new_axis(a: NxTensor, axis: Int) -> NxTensor
 @external(erlang, "Elixir.Nx", "divide")
 pub fn divide(a: NxTensor, b: Float) -> NxTensor
 
-@external(erlang, "Elixir.Nx", "put_slice")
-pub fn put_slice(a: NxTensor, indices: List(Int), value: NxTensor) -> NxTensor
-
 @external(erlang, "Elixir.Nx", "concatenate")
 pub fn concatenate(a: List(NxTensor), opts opts: List(NxOpts)) -> NxTensor
-
-// pub fn convert_func_params(
-//   func: fn(Float, List(Float)) -> Float,
-// ) -> fn(NxTensor, NxTensor) -> Float {
-//   fn(x: NxTensor, params: NxTensor) -> Float {
-//     func(to_number(x), to_list_1d(params))
-//   }
-// }


### PR DESCRIPTION
From the prototyping of the functions there were a lot of back and fourth between converting Gleam's `List(Float)` to `Nx.Tensor` and vice versa. This can be expensive and should only be used when truly needed.

This PR moves a bunch of calculations from Nx to Gleam so we can minimize the amount of conversions between those data types.